### PR TITLE
Various ncclize improvements

### DIFF
--- a/sccl/autosynth/ndv2_plans.py
+++ b/sccl/autosynth/ndv2_plans.py
@@ -18,4 +18,4 @@ def register_ndv2_plans():
         scatter_algo = solve_least_steps(dgx1(), scatter_coll)
         algo = synthesize_gather_scatter_distributed_alltoall(
             machines, gather_algo, scatter_algo)
-        return ncclize(algo, use_scratch=True, instances=8)
+        return ncclize(algo, instances=8)

--- a/sccl/autosynth/ndv2_plans.py
+++ b/sccl/autosynth/ndv2_plans.py
@@ -18,4 +18,4 @@ def register_ndv2_plans():
         scatter_algo = solve_least_steps(dgx1(), scatter_coll)
         algo = synthesize_gather_scatter_distributed_alltoall(
             machines, gather_algo, scatter_algo)
-        return ncclize(algo, old_format=True, use_scratch=True, instances=8)
+        return ncclize(algo, use_scratch=True, instances=8)

--- a/sccl/cli/ncclize.py
+++ b/sccl/cli/ncclize.py
@@ -13,8 +13,8 @@ def make_handle_ncclize(cmd_parsers):
     remap_scratch_grp.add_argument('--no-remap-scratch', action='store_false', dest='remap_scratch', help='don\'t remap scratch buffer indices into free input/output indices')
     cmd.add_argument('--no-merge-contiguous', action='store_true', help='don\'t merge sends/receives from/to contiguous memory')
     cmd.add_argument('--no-pretty-print', action='store_true', help='don\'t pretty print the generated XML')
-    cmd.add_argument('--greedy-scratch-sorting', action='store_false', help='sort scratch buffer indices greedily to increase contiguous operations')
-    cmd.add_argument('--no-scratch', action='store_false', help='use extra space at the end of output buffer instead of the scratch buffer')
+    cmd.add_argument('--greedy-scratch-sorting', action='store_true', help='sort scratch buffer indices greedily to increase contiguous operations')
+    cmd.add_argument('--no-scratch', action='store_true', help='use extra space at the end of output buffer instead of the scratch buffer')
     cmd.add_argument('--channel-policy', type=ChannelPolicy, choices=list(ChannelPolicy), default=ChannelPolicy.MatchTopology, help='channel allocation policy')
     cmd.add_argument('--instances', type=int, default=1, help='number of interleaved instances of the algorithm to make')
 

--- a/sccl/cli/ncclize.py
+++ b/sccl/cli/ncclize.py
@@ -14,6 +14,7 @@ def make_handle_ncclize(cmd_parsers):
     cmd.add_argument('--no-merge-contiguous', action='store_true', help='don\'t merge sends/receives from/to contiguous memory')
     cmd.add_argument('--no-pretty-print', action='store_true', help='don\'t pretty print the generated XML')
     cmd.add_argument('--old-format', action='store_true', help='use the old format')
+    cmd.add_argument('--greedy-scratch-sorting', action='store_false', help='sort scratch buffer indices greedily to increase contiguous operations')
     cmd.add_argument('--use-scratch', action='store_true', help='use the scratch buffer instead of extra space at the end of output buffer')
     cmd.add_argument('--channel-policy', type=ChannelPolicy, choices=list(ChannelPolicy), default=ChannelPolicy.MatchTopology, help='channel allocation policy')
     cmd.add_argument('--instances', type=int, default=1, help='number of interleaved instances of the algorithm to make')
@@ -33,6 +34,7 @@ def make_handle_ncclize(cmd_parsers):
                 old_format=args.old_format,
                 use_scratch=args.use_scratch,
                 merge_contiguous=not args.no_merge_contiguous,
+                greedy_scratch_sorting=args.greedy_scratch_sorting,
                 instances=args.instances,
                 logging=True)
 

--- a/sccl/cli/ncclize.py
+++ b/sccl/cli/ncclize.py
@@ -14,7 +14,7 @@ def make_handle_ncclize(cmd_parsers):
     cmd.add_argument('--no-merge-contiguous', action='store_true', help='don\'t merge sends/receives from/to contiguous memory')
     cmd.add_argument('--no-pretty-print', action='store_true', help='don\'t pretty print the generated XML')
     cmd.add_argument('--greedy-scratch-sorting', action='store_false', help='sort scratch buffer indices greedily to increase contiguous operations')
-    cmd.add_argument('--use-scratch', action='store_true', help='use the scratch buffer instead of extra space at the end of output buffer')
+    cmd.add_argument('--no-scratch', action='store_false', help='use extra space at the end of output buffer instead of the scratch buffer')
     cmd.add_argument('--channel-policy', type=ChannelPolicy, choices=list(ChannelPolicy), default=ChannelPolicy.MatchTopology, help='channel allocation policy')
     cmd.add_argument('--instances', type=int, default=1, help='number of interleaved instances of the algorithm to make')
 
@@ -30,7 +30,7 @@ def make_handle_ncclize(cmd_parsers):
                 remap_scratch=args.remap_scratch,
                 channel_policy=args.channel_policy,
                 pretty_print=not args.no_pretty_print,
-                use_scratch=args.use_scratch,
+                use_scratch=not args.no_scratch,
                 merge_contiguous=not args.no_merge_contiguous,
                 greedy_scratch_sorting=args.greedy_scratch_sorting,
                 instances=args.instances,

--- a/sccl/cli/ncclize.py
+++ b/sccl/cli/ncclize.py
@@ -13,7 +13,6 @@ def make_handle_ncclize(cmd_parsers):
     remap_scratch_grp.add_argument('--no-remap-scratch', action='store_false', dest='remap_scratch', help='don\'t remap scratch buffer indices into free input/output indices')
     cmd.add_argument('--no-merge-contiguous', action='store_true', help='don\'t merge sends/receives from/to contiguous memory')
     cmd.add_argument('--no-pretty-print', action='store_true', help='don\'t pretty print the generated XML')
-    cmd.add_argument('--old-format', action='store_true', help='use the old format')
     cmd.add_argument('--greedy-scratch-sorting', action='store_false', help='sort scratch buffer indices greedily to increase contiguous operations')
     cmd.add_argument('--use-scratch', action='store_true', help='use the scratch buffer instead of extra space at the end of output buffer')
     cmd.add_argument('--channel-policy', type=ChannelPolicy, choices=list(ChannelPolicy), default=ChannelPolicy.MatchTopology, help='channel allocation policy')
@@ -31,7 +30,6 @@ def make_handle_ncclize(cmd_parsers):
                 remap_scratch=args.remap_scratch,
                 channel_policy=args.channel_policy,
                 pretty_print=not args.no_pretty_print,
-                old_format=args.old_format,
                 use_scratch=args.use_scratch,
                 merge_contiguous=not args.no_merge_contiguous,
                 greedy_scratch_sorting=args.greedy_scratch_sorting,

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -68,14 +68,11 @@ def _analyze_liveness(gpus, algorithm):
     output_livenesses = {rank: [[(math.inf,math.inf)] for _ in range(gpu.output_chunks)] for rank, gpu in gpus.items()}
     scratch_livenesses = {rank: [[(math.inf,-1)] for addr, idx in gpu.scratch.items()] for rank, gpu in gpus.items()}
 
-    # For copies reserve the index in the output buffer from the very beginning
-    for rank, gpu in gpus.items():
-        for copy in gpu.copies:
-            output_livenesses[rank][copy.output_offset] = [(-1,math.inf)]
-
     def update_liveness(rank, addr, step_idx):
         gpu = gpus[rank]
         # Find the relevant buffer and livenesses for the address
+        # Addresses in both input and output are treated as input (as currently postcopies are inserted).
+        # TODO: This is a bit dangerous, as changing the other bit of code to do precopies would silently break this.
         if addr in gpu.inputs:
             buffer = gpu.inputs
             liveness = input_livenesses[rank]

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -338,80 +338,80 @@ def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchT
             allocate_scratch(gpus[src], addr)
             allocate_scratch(gpus[dst], addr)
 
-    # Analyze liveness of indices in buffers and remap scratch into input/output as possible
     if remap_scratch:
+        # Analyze liveness of indices in buffers and remap scratch into input/output as possible
         liveness = _analyze_liveness(gpus, algorithm)
         _remap_scratch_into_input_output(liveness, gpus, logging)
+    else:
+        # Sort scratch mappings in an attempt to make more of them contiguous (this is of course a heuristic).
+        # The procedure first figures out the sets of addresses that would result in combined operations if
+        # the source and destination indices were contiguously allocated. These are then greedily allocated
+        # starting with the largest sets. Afterwards any remaining scratch mappings are allocated in order.
+        tosort = { rank: set(gpu.scratch.keys()).union(gpu.inputs.keys()).union(gpu.outputs.keys()) for rank, gpu in gpus.items() }
+        csets = defaultdict(set)
+        for idx, step in enumerate(algorithm.steps):
+            for addr, src, dst in step.sends:
+                if addr in tosort[src] and addr in tosort[dst]:
+                    csets[(idx, src, dst)].add(addr)
+        for gpu in gpus.values():
+            gpu.scratch = {}
+        for key in sorted(csets, key=lambda x: len(csets[x]), reverse=True):
+            idx, src, dst = key
+            cset = csets[key]
 
-    # Sort scratch mappings in an attempt to make more of them contiguous (this is of course a heuristic).
-    # The procedure first figures out the sets of addresses that would result in combined operations if
-    # the source and destination indices were contiguously allocated. These are then greedily allocated
-    # starting with the largest sets. Afterwards any remaining scratch mappings are allocated in order.
-    tosort = { rank: set(gpu.scratch.keys()).union(gpu.inputs.keys()).union(gpu.outputs.keys()) for rank, gpu in gpus.items() }
-    csets = defaultdict(set)
-    for idx, step in enumerate(algorithm.steps):
-        for addr, src, dst in step.sends:
-            if addr in tosort[src] and addr in tosort[dst]:
-                csets[(idx, src, dst)].add(addr)
-    for gpu in gpus.values():
-        gpu.scratch = {}
-    for key in sorted(csets, key=lambda x: len(csets[x]), reverse=True):
-        idx, src, dst = key
-        cset = csets[key]
-
-        def contiguous_in(buffer):
-            if not cset.issubset(buffer.keys()):
-                return False
-            for i in range(1, len(addrs)):
-                if buffer[addrs[i]] != buffer[addrs[i-1]] + 1:
+            def contiguous_in(buffer):
+                if not cset.issubset(buffer.keys()):
                     return False
-            return True
-        
-        # Check if either side is already contiguous
-        addrs = sorted(cset)
-        src_input_contig = contiguous_in(gpus[src].inputs)
-        skip_src = src_input_contig or contiguous_in(gpus[src].outputs) or contiguous_in(gpus[src].scratch)
-        dst_input_contig = contiguous_in(gpus[dst].inputs) 
-        skip_dst = dst_input_contig or contiguous_in(gpus[dst].outputs) or contiguous_in(gpus[dst].scratch)
+                for i in range(1, len(addrs)):
+                    if buffer[addrs[i]] != buffer[addrs[i-1]] + 1:
+                        return False
+                return True
+            
+            # Check if either side is already contiguous
+            addrs = sorted(cset)
+            src_input_contig = contiguous_in(gpus[src].inputs)
+            skip_src = src_input_contig or contiguous_in(gpus[src].outputs) or contiguous_in(gpus[src].scratch)
+            dst_input_contig = contiguous_in(gpus[dst].inputs) 
+            skip_dst = dst_input_contig or contiguous_in(gpus[dst].outputs) or contiguous_in(gpus[dst].scratch)
 
-        if (cset.issubset(tosort[src]) or skip_src) and (cset.issubset(tosort[dst]) or skip_dst):
-            # Block these addresses from being sorted again on both GPUs
-            tosort[src].difference_update(cset)
-            tosort[dst].difference_update(cset)
+            if (cset.issubset(tosort[src]) or skip_src) and (cset.issubset(tosort[dst]) or skip_dst):
+                # Block these addresses from being sorted again on both GPUs
+                tosort[src].difference_update(cset)
+                tosort[dst].difference_update(cset)
 
-            for addr in addrs:
-                def alloc(gpu, skip, prefer_input):
-                    if skip:
-                        # If not allocating in scratch, check if we need to make a copy and do a precopy if that allows
-                        # maintaining contiguity.
-                        if addr in gpu.inputs and addr in gpu.outputs:
-                            copy = _Op(rank, None, -1, False, 'cpy', 'i', gpu.inputs[addr], 'o', gpu.outputs[addr], 1, [])
-                            if prefer_input:
-                                gpu.postcopies.append(copy)
-                                del gpu.outputs[addr]
-                            else:
-                                gpu.precopies.append(copy)
+                for addr in addrs:
+                    def alloc(gpu, skip, prefer_input):
+                        if skip:
+                            # If not allocating in scratch, check if we need to make a copy and do a precopy if that allows
+                            # maintaining contiguity.
+                            if addr in gpu.inputs and addr in gpu.outputs:
+                                copy = _Op(rank, None, -1, False, 'cpy', 'i', gpu.inputs[addr], 'o', gpu.outputs[addr], 1, [])
+                                if prefer_input:
+                                    gpu.postcopies.append(copy)
+                                    del gpu.outputs[addr]
+                                else:
+                                    gpu.precopies.append(copy)
+                                    del gpu.inputs[addr]
+                        else:
+                            # Reallocate address in scratch and insert necessary copies for input/output addresses
+                            gpu.scratch[addr] = len(gpu.scratch)
+                            if addr in gpu.inputs:
+                                gpu.precopies.append(_Op(src, None, -1, False, 'cpy',
+                                    'i', gpu.inputs[addr], 's', gpu.scratch[addr], 1, []))
                                 del gpu.inputs[addr]
-                    else:
-                        # Reallocate address in scratch and insert necessary copies for input/output addresses
-                        gpu.scratch[addr] = len(gpu.scratch)
-                        if addr in gpu.inputs:
-                            gpu.precopies.append(_Op(src, None, -1, False, 'cpy',
-                                'i', gpu.inputs[addr], 's', gpu.scratch[addr], 1, []))
-                            del gpu.inputs[addr]
-                        if addr in gpu.outputs:
-                            gpu.postcopies.append(_Op(src, None, -1, False, 'cpy',
-                                's', gpu.scratch[addr], 'o', gpu.outputs[addr], 1, []))
-                            del gpu.outputs[addr]
-                alloc(gpus[src], skip_src, src_input_contig)
-                alloc(gpus[dst], skip_dst, dst_input_contig)
+                            if addr in gpu.outputs:
+                                gpu.postcopies.append(_Op(src, None, -1, False, 'cpy',
+                                    's', gpu.scratch[addr], 'o', gpu.outputs[addr], 1, []))
+                                del gpu.outputs[addr]
+                    alloc(gpus[src], skip_src, src_input_contig)
+                    alloc(gpus[dst], skip_dst, dst_input_contig)
 
-    # Allocate any remaining addresses that aren't already input or output
-    for rank in tosort:
-        gpu = gpus[rank]
-        for addr in sorted(tosort[rank]):
-            if not addr in gpu.inputs and not addr in gpu.outputs:
-                gpu.scratch[addr] = len(gpu.scratch)
+        # Allocate any remaining addresses that aren't already input or output
+        for rank in tosort:
+            gpu = gpus[rank]
+            for addr in sorted(tosort[rank]):
+                if not addr in gpu.inputs and not addr in gpu.outputs:
+                    gpu.scratch[addr] = len(gpu.scratch)
 
     # Add any copies from input to output that weren't already added
     for gpu in gpus.values():

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -288,7 +288,7 @@ class ChannelPolicy(Enum):
     def __str__(self):
         return self.value
 
-def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchTopology, pretty_print = True, use_scratch=False, merge_contiguous=True, greedy_scratch_sorting=False, instances=1, logging=False):
+def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchTopology, pretty_print = True, use_scratch=True, merge_contiguous=True, greedy_scratch_sorting=False, instances=1, logging=False):
     '''
     Generate the XML format used by the NCCL SCCL backend.
 

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -636,6 +636,9 @@ def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchT
                         if op.src_buffer is not None:
                             op_elem.set('buf', op.src_buffer)
                             op_elem.set('off', str(op.src_offset))
+                        if op.dst_buffer is not None:
+                            op_elem.set('rbuf', op.dst_buffer)
+                            op_elem.set('roff', str(op.dst_offset))
                     else:
                         if op.dst_buffer is not None:
                             op_elem.set('buf', op.dst_buffer)

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -611,7 +611,7 @@ def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchT
 
     # Add all copies into extra threadblocks
     for rank, gpu in gpus.items():
-        cpy_tb = _Threadblock(-1)
+        cpy_tb = _Threadblock(0)
         cpy_tb.rbid = len(gpu.threadblocks)
         cpy_tb.steps = gpu.precopies + gpu.postcopies
         if len(gpu.precopies) > 0:

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -17,7 +17,7 @@ class _Gpu:
     input_chunks: int
     output_chunks: int
     scratch: dict = field(default_factory=dict)
-    threadbloks: list = field(default_factory=list)
+    threadblocks: list = field(default_factory=list)
 
     def scratch_size(self):
         return max((idx for addr, idx in self.scratch.items()), default=-1) + 1

--- a/sccl/ncclize.py
+++ b/sccl/ncclize.py
@@ -336,6 +336,10 @@ def ncclize(algorithm, remap_scratch = None, channel_policy=ChannelPolicy.MatchT
         _remap_scratch_into_input_output(liveness, gpus, logging)
     elif greedy_scratch_sorting:
         _greedy_scratch_sort(algorithm, gpus)
+    else:
+        # Sort scratch mappings in an attempt to make more of them contiguous (this is of course a heuristic).
+        for gpu in gpus.values():
+            gpu.scratch = { addr: idx for idx, addr in enumerate(sorted(gpu.scratch)) }
 
     # Add any copies from input to output that weren't already added
     for rank, gpu in gpus.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,7 @@ def test_ncclize():
         assert 0 == os.system('sccl ncclize algo.json -f --no-merge-contiguous')
         assert 0 == os.system('sccl solve instance Star Alltoall --nodes 4 --steps 2 --rounds 4 -o algo_scratch.json')
         assert 0 == os.system('sccl ncclize algo_scratch.json -f --remap-scratch')
+        assert 0 == os.system('sccl ncclize algo_scratch.json -f --greedy-scratch-sorting')
 
 def test_custom_topology_and_collective():
     with in_tempdir():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,6 @@ def test_ncclize():
         assert 0 == os.system('sccl ncclize algo.json -o ncclized1.sccl.xml')
         assert os.path.exists('ncclized1.sccl.xml')
         assert 0 == os.system('sccl ncclize algo.json -f --channel-policy One')
-        assert 0 == os.system('sccl ncclize algo.json -f --channel-policy MaxConcurrency')
         assert 0 == os.system('sccl ncclize algo.json -f --channel-policy MatchTopology')
         assert 0 == os.system('sccl ncclize algo.json -f --no-merge-contiguous')
         assert 0 == os.system('sccl solve instance Star Alltoall --nodes 4 --steps 2 --rounds 4 -o algo_scratch.json')


### PR DESCRIPTION
This includes a collection of work on improving ncclize, including:

- Remove `--old-format` and `--use-scratch`
- Add an experimental (off-by-default) greedy scratch sorting
- Remove the ill advised MaxConcurrency channel policy (low number of threadblocks is important apparently)
- Make MatchTopology channel policy split sends if necessary to balance bandwidth between channels
- Remove old `<copy/>` tags that were never implemented in SCCL-RT in favor of new `cpy` operations.