### PR TITLE
Example and improvements to sccl.init

### DIFF
--- a/examples/requirements_sccl_init.txt
+++ b/examples/requirements_sccl_init.txt
@@ -1,0 +1,1 @@
+git+https://github.com/parasailteam/sccl-presynth

--- a/examples/sccl_init.py
+++ b/examples/sccl_init.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+
+def show():
+    print()
+    print(f"SCCL_CONFIG = {os.environ['SCCL_CONFIG']}")
+    print(f"NCCL_MIN_NCHANNELS = {os.environ['NCCL_MIN_NCHANNELS']}")
+    print(f"NCCL_NET_SHARED_BUFFERS = {os.environ['NCCL_NET_SHARED_BUFFERS']}")
+    print(f"Contents of {os.environ['SCCL_CONFIG']}:")
+    with open(os.environ['SCCL_CONFIG']) as f:
+        print(f.read())
+    print()
+
+
+print('=== Trigger a builtin synthesis plan ===')
+
+import sccl
+sccl.init(9, 'ndv4', ('alltoall', '1GB'))
+
+show()
+
+
+print('=== Register additional plans from a library ===')
+
+import sccl_presynth
+sccl.init(3, 'ndv2',
+    ('alltoall', '1GB'),
+    ('allgather', (128, '1KB')))
+
+show()
+
+
+print('=== Register custom plans ===')
+
+from sccl.autosynth.registry import register_synthesis_plan
+
+@register_synthesis_plan('alltoall', 'ndv9000', lambda m: m == 1, ('1MB', None))
+def alltoall_9000(machines):
+    return """<algo name="a2andv9000" nchunksperloop="2" nchannels="1" inplace="0" ngpus="2" proto="Simple">
+    ...
+    </algo>"""
+
+sccl.init(1, 'ndv9000', ('alltoall', '2MB'))
+
+show()
+
+
+print('=== Overlapping size ranges ===')
+
+register_synthesis_plan('alltoall', 'ndv9000', lambda m: m == 1, (0, '1KB'), protocol='LL')(alltoall_9000)
+register_synthesis_plan('alltoall', 'ndv9000', lambda m: m == 1, ('1KB', '1MB'), protocol='LL128')(alltoall_9000)
+
+sccl.init(1, 'ndv9000', ('alltoall', ('2KB', None)))
+
+show()

--- a/sccl/autosynth/__init__.py
+++ b/sccl/autosynth/__init__.py
@@ -13,10 +13,10 @@ import math
 import tempfile
 import humanfriendly
 
-from sccl.autosynth.dgx1_plans import register_dgx1_plans
-from sccl.autosynth.a100_plans import register_a100_plans
-register_dgx1_plans()
-register_a100_plans()
+from sccl.autosynth.ndv2_plans import register_ndv2_plans
+from sccl.autosynth.ndv4_plans import register_ndv4_plans
+register_ndv2_plans()
+register_ndv4_plans()
 
 
 def init(num_machines, machine_type, *collectives):

--- a/sccl/autosynth/ndv2_plans.py
+++ b/sccl/autosynth/ndv2_plans.py
@@ -9,9 +9,9 @@ from sccl.autosynth.registry import register_synthesis_plan
 from sccl.ncclize import ncclize
 
 
-def register_dgx1_plans():
-    @register_synthesis_plan('alltoall', 'dgx1', machines=lambda x: x >= 2)
-    def synthesize_dgx1_relay_alltoall(machines):
+def register_ndv2_plans():
+    @register_synthesis_plan('alltoall', 'ndv2', machines=lambda x: x >= 2)
+    def synthesize_ndv2_relay_alltoall(machines):
         gather_coll = gather(8, 0)
         scatter_coll = scatter(8, 1)
         gather_algo = solve_least_steps(dgx1(), gather_coll)

--- a/sccl/autosynth/ndv4_plans.py
+++ b/sccl/autosynth/ndv4_plans.py
@@ -3,9 +3,9 @@
 
 from sccl.autosynth.registry import register_synthesis_plan
 
-def register_a100_plans():
-    @register_synthesis_plan('alltoall', 'a100', machines=lambda x: x == 9)
-    def synthesize_a100_hierarchical_alltoall(machines):
+def register_ndv4_plans():
+    @register_synthesis_plan('alltoall', 'ndv4', machines=lambda x: x == 9)
+    def synthesize_ndv4_hierarchical_alltoall(machines):
         xml = ""
         nnodes = 9
         assert(machines == nnodes)

--- a/tests/test_autosynth.py
+++ b/tests/test_autosynth.py
@@ -10,12 +10,12 @@ def test_sccl_init(capsys):
     sccl.init(4, 'not_a_machine_type', ('alltoall', 0))
     out, err = capsys.readouterr()
     assert 'No plan found' in out
-    sccl.init(2, 'dgx1', ('alltoall', '1MB'))
+    sccl.init(2, 'ndv2', ('alltoall', '1MB'))
     out, err = capsys.readouterr()
-    assert 'synthesize_dgx1_relay_alltoall' in out
-    sccl.init(9, 'a100', ('alltoall', '1MB'))
+    assert 'synthesize_ndv2_relay_alltoall' in out
+    sccl.init(9, 'ndv4', ('alltoall', '1MB'))
     out, err = capsys.readouterr()
-    assert 'synthesize_a100_hierarchical_alltoall' in out
+    assert 'synthesize_ndv4_hierarchical_alltoall' in out
 
 
 def test_register_plan():


### PR DESCRIPTION
Adds an example for various usage of `sccl.init`.

Also gives known machine types dgx1 and a100 the more accurate name ndv2 and ndv4.

Makes `sccl.init` maximum sizes non-inclusive, i.e. the intervals are [min,max).