### PR TITLE
Fix sccl.init to set NCCL_ALGOS

### DIFF
--- a/sccl/autosynth/__init__.py
+++ b/sccl/autosynth/__init__.py
@@ -84,6 +84,12 @@ def init(machine_type, num_machines, *collectives):
             'SCCL_CONFIG': path,
             'NCCL_NET_SHARED_BUFFERS': '0',
         }
+        if 'NCCL_ALGOS' in os.environ and os.environ['NCCL_ALGOS'] != '':
+            existing_algos = os.environ['NCCL_ALGOS']
+            if 'SCCL' not in existing_algos:
+                os.environ['NCCL_ALGOS'] = 'SCCL,' + existing_algos
+        else:
+            env['NCCL_ALGOS'] = 'SCCL,RING,TREE'
         if machine_type == 'ndv4' and num_machines >= 16 and 'alltoall' in selected_plans:
             print(f'SCCL: Setting NCCL_IB_AR_THRESHOLD=0 (reason: alltoall and at least 16 ndv4 machines)')
             env['NCCL_IB_AR_THRESHOLD'] = '0'

--- a/tests/test_autosynth.py
+++ b/tests/test_autosynth.py
@@ -17,15 +17,20 @@ def test_sccl_init(capsys):
     out, err = capsys.readouterr()
     assert 'synthesize_ndv2_relay_alltoall' in out
     assert 'SCCL_CONFIG' in os.environ
+    assert 'NCCL_ALGOS' in os.environ and os.environ['NCCL_ALGOS'] == 'SCCL,RING,TREE'
 
+    os.environ['NCCL_ALGOS'] = 'RING'
     sccl.init('ndv4', 9, (sccl.Collective.alltoall, '1MB'))
     out, err = capsys.readouterr()
     assert 'synthesize_ndv4_hierarchical_alltoall' in out
+    assert 'NCCL_ALGOS' in os.environ and os.environ['NCCL_ALGOS'] == 'SCCL,RING'
 
+    os.environ['NCCL_ALGOS'] = 'HELLO,SCCL,WORLD'
     sccl.init('ndv4', 16, (sccl.Collective.alltoall, '1MB'))
     out, err = capsys.readouterr()
     assert 'ndv4_alltoall' in out
     assert 'NCCL_IB_AR_THRESHOLD' in os.environ
+    assert 'NCCL_ALGOS' in os.environ and os.environ['NCCL_ALGOS'] == 'HELLO,SCCL,WORLD'
 
 
 def test_register_plan():


### PR DESCRIPTION
Previously we had been executing in environments where `NCCL_ALGOS` already included SCCL. Now SCCL will be added to the list whenever necessary, if any SCCL algorithms are to be loaded.