### PR TITLE
Add printing available plans

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ z3-solver
 argcomplete
 lxml
 humanfriendly
+tabulate
 pytest
 pytest-cov
 pytest-xdist

--- a/sccl/__init__.py
+++ b/sccl/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from sccl.autosynth import init
+from sccl.autosynth import init, tabulate_plans, print_plans
 from sccl.autosynth import ndv2_perm
 from sccl.autosynth import Collective

--- a/sccl/__main__.py
+++ b/sccl/__main__.py
@@ -24,6 +24,7 @@ def main():
     handlers.append(make_distributors(cmd_parsers))
     handlers.append(make_analyses(cmd_parsers))
     handlers.append(make_handle_ncclize(cmd_parsers))
+    handlers.append(make_plans(cmd_parsers))
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()

--- a/sccl/cli/__init__.py
+++ b/sccl/cli/__init__.py
@@ -5,3 +5,4 @@ from .solve import *
 from .distribute import *
 from .analyze import *
 from .ncclize import *
+from .plans import *

--- a/sccl/cli/plans.py
+++ b/sccl/cli/plans.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from .common import *
+from sccl.autosynth import *
+
+def make_plans(cmd_parsers):
+    handler_funcs = []
+    handler_funcs.append(make_handle_list)
+
+    return make_cmd_category(cmd_parsers, 'plans', 'subcommand', handler_funcs)
+
+def make_handle_list(cmd_parsers):
+    cmd = cmd_parsers.add_parser('list')
+
+    def handle(args, command):
+        if command != 'list':
+            return False
+
+        print_plans()
+        return True
+    
+    return handle

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'argcomplete',
         'lxml',
         'humanfriendly',
+        'tabulate',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This implements issue #23 . The printing is available through `sccl.print_plans()` or in the CLI with `sccl plans list`. Both print out a GitHub-compatible markdown table like this:

| Machine   | Collective   | # machines   | From   | To       | Protocol   |   Priority | Plan name                           |
|-----------|--------------|--------------|--------|----------|------------|------------|-------------------------------------|
| ndv2      | alltoall     | >=2          | 1 MB   | infinity | Simple     |          0 | call synthesize_ndv2_relay_alltoall |
| ndv4      | allreduce    | 1            | 256 KB | 20 MB    | LL128      |          0 | run ndv4_ring_allreduce             |
| ndv4      | alltoall     | 8,16,32      | 1 MB   | 32 MB    | LL128      |          0 | run ndv4_alltoall                   |
| ndv4      | alltoall     | 64           | 1 MB   | 32 MB    | LL128      |          0 | run ndv4_alltoall                   |
| ndv4      | alltoall     | 8,16,32      | 32 MB  | infinity | Simple     |          0 | run ndv4_alltoall                   |
| ndv4      | alltoall     | 64           | 32 MB  | infinity | Simple     |          0 | run ndv4_alltoall                   |